### PR TITLE
chore(workflows): migrate ai-agent workflow to mz-ai-agent-action

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -21,11 +21,16 @@ on:
         description: Provider-specific options in key=value,key=value format
         required: false
         type: string
+      timeout-minutes:
+        description: Job timeout in minutes
+        required: false
+        default: 30
+        type: number
 
 jobs:
   execute-agent:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs['timeout-minutes'] }}
 
     permissions:
       contents: write

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -4,21 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       provider:
-        description: 'AI provider ID'
+        description: AI agent/tool ID
         required: false
-        default: 'gemini'
+        default: gemini-cli
         type: string
       prompt:
-        description: 'Instruction for the AI Agent'
+        description: Instruction for the AI Agent
         required: true
         type: string
       model:
-        description: 'Gemini Model ID'
+        description: Model ID for the selected agent/tool
         required: false
-        default: 'gemini-2.5-flash'
-  schedule:
-    # Run every Monday and Thursday at 00:00 UTC
-    - cron: '0 0 * * 1,4'
+        default: gemini-3-flash-preview
+        type: string
+      extra-options:
+        description: Provider-specific options in key=value,key=value format
+        required: false
+        type: string
 
 jobs:
   execute-agent:
@@ -29,7 +31,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Execute AI Task
         if: github.event_name != 'schedule'
@@ -38,7 +40,5 @@ jobs:
           provider: ${{ inputs.provider }}
           prompt: ${{ inputs.prompt }}
           model: ${{ inputs.model }}
+          extra-options: ${{ inputs.extra-options }}
           credentials-map: ${{ secrets.AI_AGENT_CREDENTIALS }}
-          location: global
-          artifact-name: agent-result-log
-          retention-days: 1

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -24,41 +24,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set Gemini CLI installation directory
-        run: echo "GEMINI_CLI_DIR=$HOME/.gemini-cli" >> $GITHUB_ENV
-
-      - name: Cache Gemini CLI
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.GEMINI_CLI_DIR }}
-          key: ${{ runner.os }}-gemini-cli
-          restore-keys: |
-            ${{ runner.os }}-gemini-cli-
-
-      - name: Install Gemini CLI
-        run: |
-          if [ ! -d "$GEMINI_CLI_DIR" ]; then
-            npm install --prefix "$GEMINI_CLI_DIR" @google/gemini-cli
-          else
-            echo "gemini-cli already installed, skipping installation"
-          fi
+      - uses: actions/checkout@v6
 
       - name: Execute AI Task
         if: github.event_name != 'schedule'
-        run: |
-          sanitized_prompt=$(printf '%s' "$PROMPT" | tr '\n' ' ' | tr -d "()|&;<>\`\$\"\\\\")
-          npx --prefix "$GEMINI_CLI_DIR" gemini --model "$GEMINI_MODEL" "$sanitized_prompt" 2>&1 | tee agent_output.txt
-        env:
-          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          PROMPT: ${{ inputs.prompt }}
-          GEMINI_MODEL: ${{ inputs.model }}
-
-      - name: Upload Agent Output
-        if: github.event_name != 'schedule' && always()
-        uses: actions/upload-artifact@v4
+        uses: mz-codes/mz-ai-agent-action@v1
         with:
-          name: agent-result-log
-          path: agent_output.txt
+          provider: gemini
+          prompt: ${{ inputs.prompt }}
+          model: ${{ inputs.model }}
+          credentials-map: ${{ secrets.AI_AGENT_CREDENTIALS }}
+          location: global
+          artifact-name: agent-result-log
           retention-days: 1

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -3,6 +3,11 @@ name: AI Agent
 on:
   workflow_dispatch:
     inputs:
+      provider:
+        description: 'AI provider ID'
+        required: false
+        default: 'gemini'
+        type: string
       prompt:
         description: 'Instruction for the AI Agent'
         required: true
@@ -30,7 +35,7 @@ jobs:
         if: github.event_name != 'schedule'
         uses: mz-codes/mz-ai-agent-action@v1
         with:
-          provider: gemini
+          provider: ${{ inputs.provider }}
           prompt: ${{ inputs.prompt }}
           model: ${{ inputs.model }}
           credentials-map: ${{ secrets.AI_AGENT_CREDENTIALS }}


### PR DESCRIPTION
## Summary

- replace the duplicated Gemini CLI setup with `mz-codes/mz-ai-agent-action@v1`
- switch workflow credentials to `${{ secrets.AI_AGENT_CREDENTIALS }}`
- preserve the existing dispatch inputs, schedule, permissions, and artifact contract

Refs: STAFF-129
